### PR TITLE
Fixed a issue that prevented combining explode rolls with other operations

### DIFF
--- a/spec/dice.spec.ts
+++ b/spec/dice.spec.ts
@@ -40,5 +40,11 @@ describe('Dice', () => {
       const exp = dice.roll('2d10kl');
       expect(exp.total).toBe(4);
     });
+    it('correctly handles explode with other operations (2d10!r)', () => {
+      const mock = new MockListRandomProvider([10, 1, 4, 2]);
+      const dice = new Dice(null, mock);
+      const exp = dice.roll('2d10!r');
+      expect(exp.total).toBe(16);
+    });
   });
 });

--- a/spec/parser/dice-parser.parseExplode.spec.ts
+++ b/spec/parser/dice-parser.parseExplode.spec.ts
@@ -44,7 +44,7 @@ describe('DiceParser', () => {
       expect(mod.getAttribute('compound')).toBe(false);
       expect(mod.getAttribute('penetrate')).toBe(true);
     });
-    it('can correctly parse an explode modifier (!p).', () => {
+    it('can correctly parse an explode modifier (!!p).', () => {
       const lexer = new MockLexer([
         new Token(TokenType.Exclamation, 0, '!'),
         new Token(TokenType.Exclamation, 1, '!'),

--- a/src/parser/dice-parser.class.ts
+++ b/src/parser/dice-parser.class.ts
@@ -247,8 +247,8 @@ export class DiceParser extends BasicParser {
     if (token.type === TokenType.Identifier) {
       if (token.value === 'p') {
         root.setAttribute('penetrate', true);
+        this.lexer.getNextToken(); // Consume p.
       }
-      this.lexer.getNextToken(); // Consume p.
     }
 
     const tokenType = this.lexer.peekNextToken().type;


### PR DESCRIPTION
The logic to check for `exploding penetrate` rules consumed the next identifier (even if was not a `p`).  This prevented using other rules with exploding dice (eg: `4d6!r`, the `reroll` was ignored).

This small fix only consumes an identifier if it is a `p`.