### PR TITLE
[PROPOSAL] Added the possibility to add decorators to individual roll results.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,41 @@ const dice = new Dice(null, null, {
 const result1 = dice.roll("50d10");
 console.log(result1.errors); // Outputs ["Invalid number of rolls: 50. Maximum allowed: 20."]
 const result2 = dice.roll("10d500");
-console.log(result2.errors); // Outputs ["Invalid number of dice sides: 500. Maximum allowed: 500."]
+console.log(result2.errors); // Outputs ["Invalid number of dice sides: 500. Maximum allowed: 100."]
+```
+
+#### Adding decorators to rolls in rendered expression
+
+When viewing individual roll results, its useful to know what was considered in the final result. The `renderExpressionDecorators` option inserts aditional information to roll results. The following symbols are added, depending on the executed rules:
+* reroll: ↻
+* explode: !
+* drop: ↓
+* critical: *
+* sucess: ✓
+
+```typescript
+const dice = new Dice(null, null, {
+    renderExpressionDecorators: true, // will render roll decorators
+});
+const result = dice.roll("4d10!");
+console.log(result.renderedExpression); // Outputs "[3, 10!, 6, 7, 6 ]!" (note the exclamation mark added to the exploded roll)
+```
+
+#### Using custom roll decorators
+
+You can also add your own roll decorators. Use the option `decorators` to specify, for each rule type, a string that will be added after the result or an array with strings that will be added before and after the roll value.
+
+```typescript
+const dice = new Dice(null, null, {
+    renderExpressionDecorators: true, // will render roll decorators
+    decorators: {
+        reroll: ['<r>', '</r>'], // example output: <r>1</r>
+        explode: ['<e>', '</e>'], // example output: <e>10</e>
+        drop: 'd', // example output: 2d
+        critical: 'c', // example output: 10c
+        success: 's', // example output: 9s
+    },
+});
 ```
 
 #### Dice Expression Syntax

--- a/spec/generator/dice-generator.generate.dice.spec.ts
+++ b/spec/generator/dice-generator.generate.dice.spec.ts
@@ -102,6 +102,63 @@ describe('DiceGenerator', () => {
 
       expect(generator.generate(dice)).toBe('[4, 5, 6]');
     });
+    it('generates dice decoration ({renderExpressionDecorators: true}).', () => {
+      const dice = Ast.Factory.create(Ast.NodeType.Dice).setAttribute('sides', 6);
+
+      dice.addChild(Ast.Factory.create(Ast.NodeType.DiceRoll).setAttribute('value', 1).setAttribute('reroll', true));
+      dice.addChild(Ast.Factory.create(Ast.NodeType.DiceRoll).setAttribute('value', 6).setAttribute('explode', true));
+      dice.addChild(Ast.Factory.create(Ast.NodeType.DiceRoll).setAttribute('value', 1).setAttribute('drop', true));
+      dice.addChild(Ast.Factory.create(Ast.NodeType.DiceRoll).setAttribute('value', 6).setAttribute('critical', true));
+      dice.addChild(Ast.Factory.create(Ast.NodeType.DiceRoll).setAttribute('value', 6).setAttribute('success', true));
+
+      const generator = new Generator.DiceGenerator({renderExpressionDecorators: true});
+
+      expect(generator.generate(dice)).toBe('[1↻, 6!, 1↓, 6*, 6✓]');
+    });
+    it('generates custom dice decoration ({renderExpressionDecorators: true, decorators: {...}}).', () => {
+      const dice = Ast.Factory.create(Ast.NodeType.Dice).setAttribute('sides', 6);
+
+      dice.addChild(Ast.Factory.create(Ast.NodeType.DiceRoll).setAttribute('value', 1).setAttribute('reroll', true));
+      dice.addChild(Ast.Factory.create(Ast.NodeType.DiceRoll).setAttribute('value', 6).setAttribute('explode', true));
+      dice.addChild(Ast.Factory.create(Ast.NodeType.DiceRoll).setAttribute('value', 1).setAttribute('drop', true));
+      dice.addChild(Ast.Factory.create(Ast.NodeType.DiceRoll).setAttribute('value', 6).setAttribute('critical', true));
+      dice.addChild(Ast.Factory.create(Ast.NodeType.DiceRoll).setAttribute('value', 6).setAttribute('success', true));
+
+      const generator = new Generator.DiceGenerator({
+        renderExpressionDecorators: true,
+        decorators: {
+          reroll: 'r',
+          explode: 'e',
+          drop: 'd',
+          critical: 'c',
+          success: 's',
+        },
+      });
+
+      expect(generator.generate(dice)).toBe('[1r, 6e, 1d, 6c, 6s]');
+    });
+    it('generates custom dice decoration ({renderExpressionDecorators: true, decorators: {...}}).', () => {
+      const dice = Ast.Factory.create(Ast.NodeType.Dice).setAttribute('sides', 6);
+
+      dice.addChild(Ast.Factory.create(Ast.NodeType.DiceRoll).setAttribute('value', 1).setAttribute('reroll', true));
+      dice.addChild(Ast.Factory.create(Ast.NodeType.DiceRoll).setAttribute('value', 6).setAttribute('explode', true));
+      dice.addChild(Ast.Factory.create(Ast.NodeType.DiceRoll).setAttribute('value', 1).setAttribute('drop', true));
+      dice.addChild(Ast.Factory.create(Ast.NodeType.DiceRoll).setAttribute('value', 6).setAttribute('critical', true));
+      dice.addChild(Ast.Factory.create(Ast.NodeType.DiceRoll).setAttribute('value', 6).setAttribute('success', true));
+
+      const generator = new Generator.DiceGenerator({
+        renderExpressionDecorators: true,
+        decorators: {
+          reroll: ['<r>', '</r>'],
+          explode: ['<e>', '</e>'],
+          drop: ['<d>', '</d>'],
+          critical: ['<c>', '</c>'],
+          success: ['<s>', '</s>'],
+        },
+      });
+
+      expect(generator.generate(dice)).toBe('[<r>1</r>, <e>6</e>, <d>1</d>, <c>6</c>, <s>6</s>]');
+    });
     it('throws on malformed dice expression (2d).', () => {
       const dice = Ast.Factory.create(Ast.NodeType.Dice);
       dice.addChild(Ast.Factory.create(Ast.NodeType.Number).setAttribute('value', 2));

--- a/spec/interpreter/dice-interpreter.evaluate.explode.spec.ts
+++ b/spec/interpreter/dice-interpreter.evaluate.explode.spec.ts
@@ -112,6 +112,34 @@ describe('DiceInterpreter', () => {
 
       expect(dice.getChildCount()).toBe(5);
     });
+    it('evaluates generating new roll after exploded die (4d6!).', () => {
+      const exp = Ast.Factory.create(Ast.NodeType.Explode)
+        .setAttribute('compound', false)
+        .setAttribute('penetrate', false);
+
+      const dice = Ast.Factory.create(Ast.NodeType.Dice);
+      dice.addChild(Ast.Factory.create(Ast.NodeType.Number).setAttribute('value', 4));
+      dice.addChild(Ast.Factory.create(Ast.NodeType.Number).setAttribute('value', 6));
+
+      exp.addChild(dice);
+
+      const mockList = new MockListRandomProvider();
+      mockList.numbers.push(
+        4, 6, 5, 2, 3,
+      );
+
+      const interpreter = new Interpreter.DiceInterpreter(null, mockList);
+      const errors: Interpreter.InterpreterError[] = [];
+      expect(interpreter.evaluate(exp, errors)).toBe(20);
+
+      expect(dice.getChildCount()).toBe(5);
+      expect(dice.getChild(0).getAttribute('value')).toBe(4);
+      expect(dice.getChild(1).getAttribute('value')).toBe(6);
+      expect(dice.getChild(1).getAttribute('explode')).toBe(true);
+      expect(dice.getChild(2).getAttribute('value')).toBe(3); // next roll inserted after exploding die
+      expect(dice.getChild(3).getAttribute('value')).toBe(5);
+      expect(dice.getChild(4).getAttribute('value')).toBe(2);
+    });
     it('errors if condition includes all dice faces (4d6!>=1).', () => {
       const exp = Ast.Factory.create(Ast.NodeType.Explode)
         .setAttribute('compound', false)

--- a/src/dice.class.ts
+++ b/src/dice.class.ts
@@ -7,13 +7,13 @@ import { DiceLexer } from './lexer/dice-lexer.class';
 import { Parser } from './parser';
 import { DiceParser } from './parser/dice-parser.class';
 import { RandomProvider } from './random';
-import { InterpreterOptions } from './interpreter/interpreter-options.interface';
+import { Options } from './options.interface';
 
 export class Dice {
   constructor(
     protected functions?: FunctionDefinitionList,
     protected randomProvider?: RandomProvider,
-    protected options?: InterpreterOptions,
+    protected options?: Options,
   ) { }
 
   roll(input: string | CharacterStream): DiceResult {
@@ -37,6 +37,6 @@ export class Dice {
   }
 
   protected createGenerator(): DiceGenerator {
-    return new DiceGenerator();
+    return new DiceGenerator(this.options);
   }
 }

--- a/src/interpreter/interpreter-options.interface.ts
+++ b/src/interpreter/interpreter-options.interface.ts
@@ -1,4 +1,0 @@
-export interface InterpreterOptions {
-  maxRollTimes?: number;
-  maxDiceSides?: number;
-}

--- a/src/options.interface.ts
+++ b/src/options.interface.ts
@@ -1,0 +1,12 @@
+export interface Options {
+  maxRollTimes?: number;
+  maxDiceSides?: number;
+  renderExpressionDecorators?: boolean;
+  decorators?: {
+    reroll?: string | string[],
+    explode?: string | string[],
+    drop?: string | string[],
+    critical?: string | string[],
+    success?: string | string[],
+  };
+}

--- a/test.js
+++ b/test.js
@@ -1,0 +1,5 @@
+const { Dice } = require("./dist");
+
+const dice = new Dice(null, null, {renderExpressionDecorators: true});
+console.log(dice.roll("2d20").renderedExpression);
+console.log(dice.roll("4d4>=3").renderedExpression);


### PR DESCRIPTION
Roll20's rendered expression includes some aditional information (like what result was dropped, rerolled, critical, etc). To include this functionality, without forcing the user to implement his own `generator`, I've created the concept of decorators: aditional text that is rendered with die roll result if some rule was applied.

Default decorators (must be enabled by using the `renderExpressionDecorators` option):
* reroll: ↻
* explode: !
* drop: ↓
* critical: *
* sucess: ✓

```typescript
const dice = new Dice(null, null, {
    renderExpressionDecorators: true, // will render roll decorators
});
const result = dice.roll("4d10!");
console.log(result.renderedExpression); // Outputs "[3, 10!, 6, 7, 6 ]!"
```

Custom decorators:
```typescript
const dice = new Dice(null, null, {
    renderExpressionDecorators: true, // will render roll decorators
    decorators: {
        reroll: ['<r>', '</r>'], // example output: <r>1</r>
        explode: ['<e>', '</e>'], // example output: <e>10</e>
        drop: 'd', // example output: 2d
        critical: 'c', // example output: 10c
        success: 's', // example output: 9s
    },
});
```

This would allow adding custom html with custom styling around dice rolls.

This update also made explode/rerolls insert new values after the exploded/rerolled value (to look more like Roll20). 

What do you think about this? Its a good approach? Or each one should implement their own generator?