### PR TITLE
Allowed dice rolls with upper case D

### DIFF
--- a/spec/dice.spec.ts
+++ b/spec/dice.spec.ts
@@ -40,5 +40,11 @@ describe('Dice', () => {
       const exp = dice.roll('2d10kl');
       expect(exp.total).toBe(4);
     });
+    it('correctly handles dice expressions with an upper case D (4D6)', () => {
+      const mock = new MockListRandomProvider([2, 3, 4, 5]);
+      const dice = new Dice(null, mock);
+      const exp = dice.roll('4D6');
+      expect(exp.total).toBe(14);
+    });
   });
 });

--- a/spec/parser/dice-parser.parseDice.spec.ts
+++ b/spec/parser/dice-parser.parseDice.spec.ts
@@ -39,6 +39,24 @@ describe('DiceParser', () => {
       expect(dice.getChild(1).type).toBe(NodeType.DiceSides);
       expect(dice.getChild(1).getAttribute('value')).toBe('fate');
     });
+    it('can correctly parse a dice roll with an upper case D.', () => {
+      const lexer = new MockLexer([
+        new Token(TokenType.Number, 0, '4'),
+        new Token(TokenType.Identifier, 0, 'D'),
+        new Token(TokenType.Number, 1, '6')
+      ]);
+      const parser = new Parser.DiceParser(lexer);
+      const result = new ParseResult();
+      const dice = parser.parseDice(result);
+      expect(result.errors.length).toBe(0);
+
+      expect(dice.type).toBe(NodeType.Dice);
+      expect(dice.getChildCount()).toBe(2);
+      expect(dice.getChild(0).type).toBe(NodeType.Number);
+      expect(dice.getChild(0).getAttribute('value')).toBe(4);
+      expect(dice.getChild(1).type).toBe(NodeType.DiceSides);
+      expect(dice.getChild(1).getAttribute('value')).toBe(6);
+    });
     it('can correctly parse a simple dice roll with pre-parsed number.', () => {
       const lexer = new MockLexer([
         new Token(TokenType.Number, 0, '10'),

--- a/src/parser/dice-parser.class.ts
+++ b/src/parser/dice-parser.class.ts
@@ -96,7 +96,7 @@ export class DiceParser extends BasicParser {
     const token = this.lexer.peekNextToken();
     switch (token.type) {
       case TokenType.Identifier:
-        if (token.value === 'd' || token.value === 'dF') {
+        if (token.value === 'd' || token.value === 'D' || token.value === 'dF') {
           root = this.parseDice(result);
         } else {
           root = this.parseFunction(result);
@@ -215,6 +215,7 @@ export class DiceParser extends BasicParser {
 
     switch (token.value) {
       case 'd':
+      case 'D':
         const sidesToken = this.expectAndConsume(result, TokenType.Number);
         root.addChild(Ast.Factory.create(Ast.NodeType.DiceSides))
           .setAttribute('value', Number(sidesToken.value));


### PR DESCRIPTION
Roll20 allows it, so I think this lib also should. 

The main reason I did this is because I use the lib in a mobile app and my text inputs automatically put the first typed letter in upper case. ( The text field is not used exclusivelly for dice expressions, so I don't want to turn `autoCapitalize` off)